### PR TITLE
chore: add instructions to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# nodejs-cloud-rad
+Helper tool to generate documentation for Nodejs client libraries and upload them to [https://cloud.google.com/nodejs/docs/reference](https://cloud.google.com/nodejs/docs/reference). 
+
+## Run locally
+
+Inside a client library, run:
+
+```
+npm install
+npm install --no-save https://github.com/googleapis/nodejs-cloud-rad#main
+
+npx @google-cloud/cloud-rad 
+```
+
+Ignore the warnings about `pip`. There should be a `_devsite` folder with yaml files. Install [`docfx`](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool). Clone https://github.com/googleapis/doc-templates outside of the client library. 
+
+Create the following `docfx.json` file inside the client library: 
+
+```
+{
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.yml"],
+        "src": "_devsite/",
+        "dest": "api"
+      }
+    ],
+    "dest": "_site",
+    "template": [
+      "/absolute path to/doc-templates/third_party/docfx/templates/devsite"
+    ]
+  } 
+}
+```
+
+Run `docfx --serve`. You should see docs without CSS styling on [localhost:8080/api](localhost:8080/api). 


### PR DESCRIPTION
Rendered here: https://github.com/googleapis/nodejs-cloud-rad/tree/fhinkel-add-running-locally-instructions