### PR TITLE
fix: support @example tags

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -331,17 +331,12 @@
      * DEFAULT VALUE: See api-extractor-defaults.json for the complete table of extractorMessageReporting mappings
      */
     "extractorMessageReporting": {
-      "default": {
-        "logLevel": "warning",
-        // "addToApiReportFile": false
+      "ae-missing-release-tag": {
+        "logLevel": "none"
       },
-
-      // "ae-extra-release-tag": {
-      //   "logLevel": "warning",
-      //   "addToApiReportFile": true
-      // },
-      //
-      // . . .
+    "ae-forgotten-export": {
+      "logLevel": "none"
+    }
     },
 
     /**
@@ -355,15 +350,42 @@
       "default": {
         "logLevel": "warning",
         // "addToApiReportFile": false
+      },
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-param-tag-missing-hyphen": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-param-tag-with-invalid-type": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-param-tag-with-invalid-optional-name": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-undefined-tag": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-param-tag-with-invalid-name": {
+        "logLevel": "none",
+        "addToApiReportFile": true
+      },
+      "tsdoc-at-sign-in-word": {
+        "logLevel": "none",
+        "addToApiReportFile": true
       }
-
-      // "tsdoc-link-tag-unescaped-text": {
-      //   "logLevel": "warning",
-      //   "addToApiReportFile": true
-      // },
+      // tsdoc-at-sign-in-word
       //
       // . . .
     }
   }
-
 }

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -22,6 +22,13 @@ mkdir -p ./etc
 
 cp node_modules/@google-cloud/cloud-rad/api-extractor.json .
 npx @microsoft/api-extractor run --local
+
+# install api-documenter deps manually because we're using a forked subdirectory
+cd node_modules/@microsoft/api-documenter/
+npm install
+npm run build
+cd ../../..
+
 npx @microsoft/api-documenter yaml --input-folder=temp
 
 # Clean up TOC

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -51,7 +51,7 @@ sed -i -e '4a\
  \ \ \ \ \ - name: Quickstart
 ' ./yaml/toc.yml
 sed -i -e '5a\
- \ \ \ \ \ \ \ homepage: quickstart.md
+ \ \ \ \ \ \ \ homepage: index.md
 ' ./yaml/toc.yml
 
 NAME=$(ls temp | sed s/.api.json*//)
@@ -75,4 +75,4 @@ cp ./yaml/toc.yml ./_devsite/toc.yml
 mv ./yaml/$NAME.yml ./_devsite/overview.yml
 
 ## readme is not allowed as filename
-cp ./README.md ./_devsite/quickstart.md
+cp ./README.md ./_devsite/index.md

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -51,7 +51,7 @@ sed -i -e '4a\
  \ \ \ \ \ - name: Quickstart
 ' ./yaml/toc.yml
 sed -i -e '5a\
- \ \ \ \ \ \ \ homepage: index.md
+ \ \ \ \ \ \ \ homepage: quickstart.md
 ' ./yaml/toc.yml
 
 NAME=$(ls temp | sed s/.api.json*//)
@@ -61,7 +61,7 @@ sed -i -e '6a\
  \ \ \ \ \ - name: Overview
 ' ./yaml/toc.yml
 sed -i -e '7a\
- \ \ \ \ \ \ \ homepage: package.html
+ \ \ \ \ \ \ \ homepage: overview.html
 ' ./yaml/toc.yml
 
 ## Copy everything to devsite
@@ -72,7 +72,7 @@ cp ./yaml/$NAME/* ./_devsite/$NAME || :
 cp ./yaml/toc.yml ./_devsite/toc.yml
 
 ## Rename the default overview page,
-mv ./yaml/$NAME.yml ./_devsite/package.yml
+mv ./yaml/$NAME.yml ./_devsite/overview.yml
 
 ## readme is not allowed as filename
-cp ./README.md ./_devsite/index.md
+cp ./README.md ./_devsite/quickstart.md

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -54,7 +54,6 @@ sed -i -e '5a\
  \ \ \ \ \ \ \ homepage: index.md
 ' ./yaml/toc.yml
 
-NAME=$(ls temp | sed s/.api.json*//)
 
 # Add package overview section
 sed -i -e '6a\
@@ -64,6 +63,7 @@ sed -i -e '7a\
  \ \ \ \ \ \ \ homepage: overview.html
 ' ./yaml/toc.yml
 
+NAME=$(ls temp | sed s/.api.json*//)
 ## Copy everything to devsite
 mkdir -p ./_devsite
 mkdir -p ./_devsite/$NAME

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -54,16 +54,16 @@ sed -i -e '5a\
  \ \ \ \ \ \ \ homepage: index.md
 ' ./yaml/toc.yml
 
+NAME=$(ls temp | sed s/.api.json*//)
 
 # Add package overview section
 sed -i -e '6a\
  \ \ \ \ \ - name: Overview
 ' ./yaml/toc.yml
 sed -i -e '7a\
- \ \ \ \ \ \ \ homepage: overview.html
+ \ \ \ \ \ \ \ homepage: package.html
 ' ./yaml/toc.yml
 
-NAME=$(ls temp | sed s/.api.json*//)
 ## Copy everything to devsite
 mkdir -p ./_devsite
 mkdir -p ./_devsite/$NAME
@@ -72,7 +72,7 @@ cp ./yaml/$NAME/* ./_devsite/$NAME || :
 cp ./yaml/toc.yml ./_devsite/toc.yml
 
 ## Rename the default overview page,
-mv ./yaml/$NAME.yml ./_devsite/overview.yml
+mv ./yaml/$NAME.yml ./_devsite/package.yml
 
 ## readme is not allowed as filename
 cp ./README.md ./_devsite/index.md

--- a/main.sh
+++ b/main.sh
@@ -43,6 +43,7 @@ name=$(cat package.json | json name | sed 's/^.*\///')
 # create docs.metadata, based on package.json and .repo-metadata.json.
 pip install -U pip
 python3 -m pip install --user gcp-docuploader
+python3 -m pip install --user six
 python3 -m docuploader create-metadata \
   --name=$name \
   --version=$(cat package.json | json version) \

--- a/main.sh
+++ b/main.sh
@@ -43,7 +43,6 @@ name=$(cat package.json | json name | sed 's/^.*\///')
 # create docs.metadata, based on package.json and .repo-metadata.json.
 pip install -U pip
 python3 -m pip install --user gcp-docuploader
-python3 -m pip install --user six
 python3 -m docuploader create-metadata \
   --name=$name \
   --version=$(cat package.json | json version) \

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Google Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@microsoft/api-documenter": "7.11.0",
-    "@microsoft/api-extractor": "7.8.2-pr1796.0"
+    "@microsoft/api-documenter": "https://gitpkg.now.sh/fhinkel/rushstack/apps/api-documenter?fhinkel-example-tag",
+    "@microsoft/api-extractor": "^7.18.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Google Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@microsoft/api-documenter": "https://gitpkg.now.sh/fhinkel/rushstack/apps/api-documenter?fhinkel-example-tag",
+    "@microsoft/api-documenter": "https://gitpkg.now.sh/googleapis/rushstack/apps/api-documenter",
     "@microsoft/api-extractor": "^7.18.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",


### PR DESCRIPTION
Use our fork of api-documenter. It supports `@example` tags. 

Use the newest version of api-extractor instead of a fixed pre-release version. This only works with our fork where we do not convert from UDP Yaml to SDP.

Install api-documenter deps manually because we're using a forked subdirectory

Drive-by fix: Supress warnings


Internally: b/174675699 and b/179483748