### PR TITLE
build: fix @microsoft/api-extractor version to 7.19.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@microsoft/api-documenter": "https://gitpkg.now.sh/googleapis/rushstack/apps/api-documenter?main",
-    "@microsoft/api-extractor": "^7.18.9"
+    "@microsoft/api-extractor": "~7.19.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
We should fix our @microsoft/api-extractor version to the last working version that is compatible with our [api-documenter fork](https://github.com/googleapis/rushstack/tree/main/apps/api-documenter). We can relax version constraints once we put tests in place to ensure any version updates do not break our yaml generation.

