### PR TITLE
build: update codeowner_team in repo-metadata.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/cx-eng
+*     @googleapis/yoshi-nodejs @googleapis/dkp
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/dkp
+*     @googleapis/yoshi-nodejs @googleapis/cx-eng
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-  "codeowner_team": "@googleapis/cx-eng",
+  "codeowner_team": "@googleapis/dkp",
   "library_type": "OTHER",
   "client_documentation": "https://www.npmjs.com/package/@google-cloud/cloud-rad",
   "release_level": "stable"


### PR DESCRIPTION
To reflect our team changing from cx-eng to dkp, we should change the CODEOWNERS file.

Fixes #63.