### PR TITLE
fix: checkout version only when provided

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -24,8 +24,7 @@ if [[ -z "$CREDENTIALS" ]]; then
   cd $(dirname $0)/../..
 fi
 
-if [ -n $VERSION ]
-then
+if [[ -n "$VERSION" ]]; then
   echo "Checking out $VERSION."
   git diff
   git checkout $VERSION


### PR DESCRIPTION
This is a bug in our bash script -- we should only checkout a branch if the $VERSION envvar is set.