### PR TITLE
fix: source main.sh to inherit working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
   "bin": {
-    "cloud-rad": ". main.sh"
+    "cloud-rad": ". ./main.sh"
   },
   "scripts": {
     "test": "env NO_UPLOAD=1 mocha"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
   "bin": {
-    "cloud-rad": ". ./main.sh"
+    "cloud-rad": "source ./main.sh"
   },
   "scripts": {
     "test": "env NO_UPLOAD=1 mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.2.21",
+  "version": "0.2.19",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.2.19",
+  "version": "0.2.21",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
   "bin": {
-    "cloud-rad": "./main.sh"
+    "cloud-rad": ". main.sh"
   },
   "scripts": {
     "test": "env NO_UPLOAD=1 mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",


### PR DESCRIPTION
This allows main.sh to inherit the working directory from it's caller (i.e. parent shell). Without sourcing the script, we do not inherit PWD.