### PR TITLE
build: use npm root instead of cd'ing into the node_modules directory to run commands

### DIFF
--- a/addLinks.js
+++ b/addLinks.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const readline = require('readline');
 

--- a/deleteBaseClasses.js
+++ b/deleteBaseClasses.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const readline = require('readline');
 

--- a/generate-devsite-base-classes.sh
+++ b/generate-devsite-base-classes.sh
@@ -21,17 +21,15 @@
 mkdir -p ./etc
 
 
-cp node_modules/@google-cloud/cloud-rad/api-extractor.json .
+cp "$(npm root)/@google-cloud/cloud-rad/api-extractor.json" .
 npx @microsoft/api-extractor run --local
 npx @googleapis/api-documenter@^7 yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/prettyPrint.js"
+pretty-print
 
 # remove interfaces from toc
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/removeInterface.js"
+remove-interface
 
 # Clean up TOC
 # Delete SharePoint item, see https://github.com/microsoft/rushstack/issues/1229

--- a/generate-devsite-base-classes.sh
+++ b/generate-devsite-base-classes.sh
@@ -26,10 +26,10 @@ npx @microsoft/api-extractor run --local
 npx @googleapis/api-documenter@^7 yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
-pretty-print
+node "$(npm root)/@google-cloud/cloud-rad/prettyPrint.js"
 
 # remove interfaces from toc
-remove-interface
+node "$(npm root)/@google-cloud/cloud-rad/removeInterface.js"
 
 # Clean up TOC
 # Delete SharePoint item, see https://github.com/microsoft/rushstack/issues/1229

--- a/generate-devsite-base-classes.sh
+++ b/generate-devsite-base-classes.sh
@@ -23,7 +23,8 @@ mkdir -p ./etc
 
 cp "$(npm root)/@google-cloud/cloud-rad/api-extractor.json" .
 npx @microsoft/api-extractor run --local
-npx @googleapis/api-documenter@^7 yaml --input-folder=temp
+echo "node $(npm root)/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp"
+node "$(npm root)/@googleapis/api-documenter/bin/api-documenter" yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
 node "$(npm root)/@google-cloud/cloud-rad/prettyPrint.js"

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -33,7 +33,7 @@ cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/common.api.json" t
 echo "cp $(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json temp"
 cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json" temp
 
-echo "npx @googleapis/api-documenter@^7 yaml --input-folder=temp"
+echo "node $(npm root)/@google-cloud/cloud-rad/node_modules/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp"
 node $(npm root)/@google-cloud/cloud-rad/node_modules/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -26,8 +26,6 @@ cp "$(npm root)/@google-cloud/cloud-rad/api-extractor.json" .
 echo "npx @microsoft/api-extractor run --local"
 npx @microsoft/api-extractor run --local
 
-echo "mkdir temp"
-mkdir temp
 # copy the common.api.json file as it is used as a base class
 # If cloud-rad is running for common, the copied file will be overwritten by api-extractor
 echo "cp $(npm root)/@google-cloud/cloud-rad/api-extractor-configs/common.api.json temp"

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -33,8 +33,9 @@ cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/common.api.json" t
 echo "cp $(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json temp"
 cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json" temp
 
-echo "node $(npm root)/@google-cloud/cloud-rad/node_modules/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp"
-node $(npm root)/@google-cloud/cloud-rad/node_modules/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp
+echo "node $(npm root)/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp"
+# npm i @googleapis/api-documenter
+node "$(npm root)/@googleapis/api-documenter/bin/api-documenter" yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
 echo "node $(npm root)/@google-cloud/cloud-rad/prettyPrint.js"

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -34,7 +34,7 @@ echo "cp $(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-l
 cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json" temp
 
 echo "npx @googleapis/api-documenter@^7 yaml --input-folder=temp"
-npx @googleapis/api-documenter@^7 yaml --input-folder=temp
+node $(npm root)/@google-cloud/cloud-rad/node_modules/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
 echo "node $(npm root)/@google-cloud/cloud-rad/prettyPrint.js"

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -37,20 +37,20 @@ echo "npx @googleapis/api-documenter@^7 yaml --input-folder=temp"
 npx @googleapis/api-documenter@^7 yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
-echo "pretty-print"
-pretty-print
+echo "node $(npm root)/@google-cloud/cloud-rad/prettyPrint.js"
+node "$(npm root)/@google-cloud/cloud-rad/prettyPrint.js"
 
 # remove common and auth from toc
-echo "delete-base-classes"
-delete-base-classes
+echo "node $(npm root)/@google-cloud/cloud-rad/deleteBaseClasses.js"
+node "$(npm root)/@google-cloud/cloud-rad/deleteBaseClasses.js"
 
 # remove interfaces from toc
-echo "remove-interface"
-remove-interface
+echo "node $(npm root)/@google-cloud/cloud-rad/removeInterface.js"
+node "$(npm root)/@google-cloud/cloud-rad/removeInterface.js"
 
 # remove protos from toc
-echo "remove-protos"
-remove-protos
+echo "node $(npm root)/@google-cloud/cloud-rad/removeProtos.js"
+node "$(npm root)/@google-cloud/cloud-rad/removeProtos.js"
 
 # Clean up TOC
 # Delete SharePoint item, see https://github.com/microsoft/rushstack/issues/1229
@@ -95,8 +95,8 @@ if [[ $numberOfFiles -ge 3 ]]; then
 fi
 
 # add href for external classes, see b/195674809
-echo "add-links"
-add-links
+echo "node $(npm root)/@google-cloud/cloud-rad/removeProtos.js"
+node "$(npm root)/@google-cloud/cloud-rad/addLinks.js"
 
 NAME=$(ls temp | sed s/.api.json*//)
 ## Copy everything to devsite

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -20,32 +20,27 @@
 
 mkdir -p ./etc
 
-
-cp node_modules/@google-cloud/cloud-rad/api-extractor.json .
+cp "$(npm root)/@google-cloud/cloud-rad/api-extractor.json" .
 npx @microsoft/api-extractor run --local
 
 # copy the common.api.json file as it is used as a base class
 # If cloud-rad is running for common, the copied file will be overwritten by api-extractor
-cp node_modules/@google-cloud/cloud-rad/api-extractor-configs/common.api.json temp
-cp node_modules/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json temp
+cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/common.api.json" temp
+cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json" temp
 
 npx @googleapis/api-documenter@^7 yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/prettyPrint.js"
+pretty-print
 
 # remove common and auth from toc
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/deleteBaseClasses.js"
+delete-base-classes
 
 # remove interfaces from toc
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/removeInterface.js"
+remove-interface
 
 # remove protos from toc
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/removeProtos.js"
+remove-protos
 
 # Clean up TOC
 # Delete SharePoint item, see https://github.com/microsoft/rushstack/issues/1229
@@ -88,8 +83,7 @@ if [[ $numberOfFiles -ge 3 ]]; then
 fi
 
 # add href for external classes, see b/195674809
-dir="$(cd "$(dirname "$0")"; pwd)"
-node "$dir/../@google-cloud/cloud-rad/addLinks.js"
+add-links
 
 NAME=$(ls temp | sed s/.api.json*//)
 ## Copy everything to devsite

--- a/generate-devsite.sh
+++ b/generate-devsite.sh
@@ -34,7 +34,6 @@ echo "cp $(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-l
 cp "$(npm root)/@google-cloud/cloud-rad/api-extractor-configs/google-auth-library.api.json" temp
 
 echo "node $(npm root)/@googleapis/api-documenter/bin/api-documenter yaml --input-folder=temp"
-# npm i @googleapis/api-documenter
 node "$(npm root)/@googleapis/api-documenter/bin/api-documenter" yaml --input-folder=temp
 
 # replace markdown code examples with html, see b/204924531
@@ -55,7 +54,6 @@ node "$(npm root)/@google-cloud/cloud-rad/removeProtos.js"
 
 # Clean up TOC
 # Delete SharePoint item, see https://github.com/microsoft/rushstack/issues/1229
-echo "sed commands"
 sed -i -e '1,3d' ./yaml/toc.yml
 # Shift everything to the left
 sed -i -e 's/^    //' ./yaml/toc.yml

--- a/main.sh
+++ b/main.sh
@@ -36,14 +36,14 @@ name=$(cat package.json | json name | sed 's/^.*\///')
 
 # Generate the data for the devsite tarball
 if [ "$name" == "common" ]; then
- echo ". generate-devsite-base-classes"
-  . generate-devsite-base-classes
+  echo ". $(npm root)/@google-cloud/cloud-rad/generate-devsite-base-classes.sh"
+  . "$(npm root)/@google-cloud/cloud-rad/generate-devsite-base-classes.sh"
 elif [ "$name" == "google-auth-library" ]; then
- echo ". generate-devsite-base-classes"
-  . generate-devsite-base-classes
+  echo ". $(npm root)/@google-cloud/cloud-rad/generate-devsite-base-classes.sh"
+  . "$(npm root)/@google-cloud/cloud-rad/generate-devsite-base-classes.sh"
 else 
  echo ". generate-devsite"
-  . generate-devsite
+  . "$(npm root)/@google-cloud/cloud-rad/generate-devsite.sh"
 fi
 
 if [[ -n "$NO_UPLOAD" ]]; then

--- a/main.sh
+++ b/main.sh
@@ -36,13 +36,13 @@ name=$(cat package.json | json name | sed 's/^.*\///')
 
 # Generate the data for the devsite tarball
 if [ "$name" == "common" ]; then
- echo "calling generate devsite base classes"
+ echo ". generate-devsite-base-classes"
   . generate-devsite-base-classes
 elif [ "$name" == "google-auth-library" ]; then
- echo "calling generate devsite base classes"
+ echo ". generate-devsite-base-classes"
   . generate-devsite-base-classes
 else 
- echo "calling generate devsite"
+ echo ". generate-devsite"
   . generate-devsite
 fi
 
@@ -51,7 +51,6 @@ if [[ -n "$NO_UPLOAD" ]]; then
   exit 0
 fi
 
-echo "python commands"
 # create docs.metadata, based on package.json and .repo-metadata.json.
 pip install -U pip
 python3 -m pip install --user gcp-docuploader

--- a/main.sh
+++ b/main.sh
@@ -21,11 +21,6 @@ if [[ -z "$CREDENTIALS" ]]; then
   # and don't set NPM_CONFIG_PREFIX.
   export NPM_CONFIG_PREFIX=${HOME}/.npm-global
   export PATH="$PATH:${NPM_CONFIG_PREFIX}/bin"
-  cd $(dirname $0)/../..
-fi
-
-if [[ -n "$MONO_REPO_CWD" ]]; then
-  cd $MONO_REPO_CWD
 fi
 
 if [[ -n "$VERSION" ]]; then
@@ -40,13 +35,12 @@ npm i json@9.0.6 -g
 name=$(cat package.json | json name | sed 's/^.*\///')
 
 # Generate the data for the devsite tarball
-dir="$(cd "$(dirname "$0")"; pwd)"
 if [ "$name" == "common" ]; then
-  . "$dir/../@google-cloud/cloud-rad/generate-devsite-base-classes.sh"
+  . generate-devsite-base-classes
 elif [ "$name" == "google-auth-library" ]; then
-  . "$dir/../@google-cloud/cloud-rad/generate-devsite-base-classes.sh"
+  . generate-devsite-base-classes
 else 
-  . "$dir/../@google-cloud/cloud-rad/generate-devsite.sh"
+  . generate-devsite
 fi
 
 if [[ -n "$NO_UPLOAD" ]]; then

--- a/main.sh
+++ b/main.sh
@@ -36,10 +36,13 @@ name=$(cat package.json | json name | sed 's/^.*\///')
 
 # Generate the data for the devsite tarball
 if [ "$name" == "common" ]; then
+ echo "calling generate devsite base classes"
   . generate-devsite-base-classes
 elif [ "$name" == "google-auth-library" ]; then
+ echo "calling generate devsite base classes"
   . generate-devsite-base-classes
 else 
+ echo "calling generate devsite"
   . generate-devsite
 fi
 
@@ -48,6 +51,7 @@ if [[ -n "$NO_UPLOAD" ]]; then
   exit 0
 fi
 
+echo "python commands"
 # create docs.metadata, based on package.json and .repo-metadata.json.
 pip install -U pip
 python3 -m pip install --user gcp-docuploader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.19-experimental",
+  "version": "0.3.0",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,11 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.13-experimental",
+  "version": "0.4.15-experimental",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
   "bin": {
-    "cloud-rad": "./main.sh",
-    "generate-devsite": "./generate-devsite.sh",
-    "generate-deviste-base-classes": "./generate-devsite-base-classes.sh",
-    "pretty-print": "./prettyPrint.js",
-    "delete-base-classes": "./deleteBaseClasses.js",
-    "remove-interface": "./removeInterface.js",
-    "remove-protos": "./removeProtos.js",
-    "add-links": "./addLinks.js"
+    "cloud-rad": "./main.sh"
   },
   "scripts": {
     "test": "env NO_UPLOAD=1 mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
@@ -8,7 +8,7 @@
     "cloud-rad": "./main.sh"
   },
   "scripts": {
-    "test": "env NO_UPLOAD=1 mocha"
+    "test": "env NO_UPLOAD=1 mocha --timeout=5000"
   },
   "author": "Google Inc",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.16-experimental",
+  "version": "0.4.19-experimental",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.12-experimental",
+  "version": "0.4.13-experimental",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.2.19",
+  "version": "0.4.12-experimental",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
   "bin": {
-    "cloud-rad": "./main.sh"
+    "cloud-rad": "./main.sh",
+    "generate-devsite": "./generate-devsite.sh",
+    "generate-deviste-base-classes": "./generate-devsite-base-classes.sh",
+    "pretty-print": "./prettyPrint.js",
+    "delete-base-classes": "./deleteBaseClasses.js",
+    "remove-interface": "./removeInterface.js",
+    "remove-protos": "./removeProtos.js",
+    "add-links": "./addLinks.js"
   },
   "scripts": {
     "test": "env NO_UPLOAD=1 mocha"
@@ -14,7 +21,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@googleapis/api-documenter": "~7.13.0",
-    "@microsoft/api-extractor": "~7.19.0"
+    "@microsoft/api-extractor": "~7.19.0",
+    "glob": "^8.0.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.15-experimental",
+  "version": "0.4.16-experimental",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/prettyPrint.js
+++ b/prettyPrint.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const readline = require('readline');
 

--- a/removeInterface.js
+++ b/removeInterface.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const readline = require('readline');
 

--- a/removeProtos.js
+++ b/removeProtos.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const readline = require('readline');
 

--- a/test/generateYamlTest.js
+++ b/test/generateYamlTest.js
@@ -30,7 +30,11 @@ before(function () {
   // Copy over nodejs-deploy library from Github
   executeCmd("git clone --branch release-v1.0.0 https://github.com/googleapis/nodejs-deploy.git " + nodejsDeployDir)
   // Install local version of cloud-rad command and generate yaml.
-  executeCmd("cd " + nodejsDeployDir + "; npm i --no-save @google-cloud/cloud-rad;. ./node_modules/.bin/cloud-rad cloud-rad")
+  executeCmd("cd " + nodejsDeployDir + "; npm i; npm run compile; npm install --no-save @google-cloud/cloud-rad;. ./node_modules/.bin/cloud-rad")
+})
+
+after(function () {
+  executeCmd(`rm -rf ${nodejsDeployDir}`);
 })
 
 describe('cloud-rad docfx generator', () => {

--- a/test/generateYamlTest.js
+++ b/test/generateYamlTest.js
@@ -30,7 +30,7 @@ before(function () {
   // Copy over nodejs-deploy library from Github
   executeCmd("git clone --branch release-v1.0.0 https://github.com/googleapis/nodejs-deploy.git " + nodejsDeployDir)
   // Install local version of cloud-rad command and generate yaml.
-  executeCmd("cd " + nodejsDeployDir + "; npm i; npm i ../..; npx @google-cloud/cloud-rad")
+  executeCmd("cd " + nodejsDeployDir + "; npm i --no-save @google-cloud/cloud-rad; . ./node_modules/.bin/cloud-rad cloud-rad")
 })
 
 describe('cloud-rad docfx generator', () => {

--- a/test/generateYamlTest.js
+++ b/test/generateYamlTest.js
@@ -30,7 +30,7 @@ before(function () {
   // Copy over nodejs-deploy library from Github
   executeCmd("git clone --branch release-v1.0.0 https://github.com/googleapis/nodejs-deploy.git " + nodejsDeployDir)
   // Install local version of cloud-rad command and generate yaml.
-  executeCmd("cd " + nodejsDeployDir + "; npm i; npm run compile; npm install --no-save @google-cloud/cloud-rad;. ./node_modules/.bin/cloud-rad")
+  executeCmd("cd " + nodejsDeployDir + "; npm i; npm run compile; npm install --no-save @google-cloud/cloud-rad;npx @google-cloud/cloud-rad . cloud-rad")
 })
 
 after(function () {

--- a/test/generateYamlTest.js
+++ b/test/generateYamlTest.js
@@ -30,7 +30,7 @@ before(function () {
   // Copy over nodejs-deploy library from Github
   executeCmd("git clone --branch release-v1.0.0 https://github.com/googleapis/nodejs-deploy.git " + nodejsDeployDir)
   // Install local version of cloud-rad command and generate yaml.
-  executeCmd("cd " + nodejsDeployDir + "; npm i --no-save @google-cloud/cloud-rad; . ./node_modules/.bin/cloud-rad cloud-rad")
+  executeCmd("cd " + nodejsDeployDir + "; npm i --no-save @google-cloud/cloud-rad;. ./node_modules/.bin/cloud-rad cloud-rad")
 })
 
 describe('cloud-rad docfx generator', () => {


### PR DESCRIPTION
Attempts to change relative links to absolute links/commands so that the script works regardless of whether we are in a split or mono repo.