### PR TITLE
fix: pipe subprocess logs to parent process

### DIFF
--- a/lib/generate-yaml.mjs
+++ b/lib/generate-yaml.mjs
@@ -17,13 +17,12 @@ import {execaNode} from 'execa';
 import fs from 'fs-extra';
 import {join} from 'path';
 
-function execAndLog(nodeBin, args, cwd) {
+async function execAndLog(nodeBin, args, cwd) {
   const cmd = join(process.cwd(), 'node_modules', '.bin', nodeBin);
   const opts = {cwd};
 
-  if (process.env.TEST) {
-    opts.stderr = opts.stdout = 'inherit';
-  }
+  opts.stdout = process.stdout
+  opts.stderr = process.stderr
 
   return execaNode(cmd, args, opts);
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "coverage": "c8 npm run test",
-    "test": "env TEST=1 mocha --timeout=50000 --require './test/helpers.mjs' --recursive './test/specs/**/*.mjs'",
-    "update-snapshots": "env SNAPSHOT_UPDATE=1 TEST=1 mocha --timeout=5000 --require './test/helpers.mjs' './test/specs/generate-devsite.mjs'"
+    "test": "env mocha --timeout=50000 --require './test/helpers.mjs' --recursive './test/specs/**/*.mjs'",
+    "update-snapshots": "env SNAPSHOT_UPDATE=1 mocha --timeout=5000 --require './test/helpers.mjs' './test/specs/generate-devsite.mjs'"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is so callers of this library can see the
output produced by api-documenter and api-extractor.
