### PR TITLE
fix: output logs for all execa commands

### DIFF
--- a/lib/generate-yaml.mjs
+++ b/lib/generate-yaml.mjs
@@ -13,9 +13,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import {execaAndLog} from './util.mjs'
+import {execaNode} from 'execa';
 import fs from 'fs-extra';
 import {join} from 'path';
+import {withLogs} from './util.mjs'
 
 
 export default async function generate({cloudRadPath, cwd}) {
@@ -40,19 +41,18 @@ export default async function generate({cloudRadPath, cwd}) {
   );
   await fs.ensureDir(apiExtractorTempPath);
   const apiExtractorCmd = join(process.cwd(), 'node_modules', '.bin', 'api-extractor')
-  await execaAndLog(apiExtractorCmd, ['run', '--local'], tmpDir, /*isNodeCmd=*/true);
+  await withLogs(execaNode)(apiExtractorCmd, ['run', '--local'], tmpDir);
   await fs.copy(apiExtractorTempPath, tmpDir);
   await fs.remove(apiExtractorTempPath);
   await fs.remove(apiExtractorConfigPath);
 
   await fs.copy(join(cloudRadPath, 'api-extractor-configs'), tmpDir);
-  const apiDocumenterCmd =  join(process.cwd(), 'node_modules', '.bin', 'api-documenter')
-  await execaAndLog(
+  const apiDocumenterCmd = join(process.cwd(), 'node_modules', '.bin', 'api-documenter')
+  await withLogs(execaNode)(
     apiDocumenterCmd,
     ['yaml', `--input-folder=${tmpDir}`, `--output-folder=${outputDir}`],
     // Use the real cwd so api-documenter can find the code samples.
     process.cwd(),
-    /*isNodeCmd=*/true
   );
 
   await fs.remove(tmpDir);

--- a/lib/generate-yaml.mjs
+++ b/lib/generate-yaml.mjs
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import {execaNodeAndLog} from './util.mjs'
+import {execaAndLog} from './util.mjs'
 import fs from 'fs-extra';
 import {join} from 'path';
 
@@ -40,18 +40,19 @@ export default async function generate({cloudRadPath, cwd}) {
   );
   await fs.ensureDir(apiExtractorTempPath);
   const apiExtractorCmd = join(process.cwd(), 'node_modules', '.bin', 'api-extractor')
-  await execaNodeAndLog(apiExtractorCmd, ['run', '--local'], tmpDir);
+  await execaAndLog(apiExtractorCmd, ['run', '--local'], tmpDir, /*isNodeCmd=*/true);
   await fs.copy(apiExtractorTempPath, tmpDir);
   await fs.remove(apiExtractorTempPath);
   await fs.remove(apiExtractorConfigPath);
 
   await fs.copy(join(cloudRadPath, 'api-extractor-configs'), tmpDir);
   const apiDocumenterCmd =  join(process.cwd(), 'node_modules', '.bin', 'api-documenter')
-  await execaNodeAndLog(
+  await execaAndLog(
     apiDocumenterCmd,
     ['yaml', `--input-folder=${tmpDir}`, `--output-folder=${outputDir}`],
     // Use the real cwd so api-documenter can find the code samples.
-    process.cwd()
+    process.cwd(),
+    /*isNodeCmd=*/true
   );
 
   await fs.remove(tmpDir);

--- a/lib/generate-yaml.mjs
+++ b/lib/generate-yaml.mjs
@@ -13,19 +13,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import {execaNode} from 'execa';
+import {execaNodeAndLog} from './util.mjs'
 import fs from 'fs-extra';
 import {join} from 'path';
 
-async function execAndLog(nodeBin, args, cwd) {
-  const cmd = join(process.cwd(), 'node_modules', '.bin', nodeBin);
-  const opts = {cwd};
-
-  opts.stdout = process.stdout
-  opts.stderr = process.stderr
-
-  return execaNode(cmd, args, opts);
-}
 
 export default async function generate({cloudRadPath, cwd}) {
   const outputDir = join(cwd, 'yaml');
@@ -48,14 +39,16 @@ export default async function generate({cloudRadPath, cwd}) {
     JSON.stringify(apiExtractorConfig, null, 2)
   );
   await fs.ensureDir(apiExtractorTempPath);
-  await execAndLog('api-extractor', ['run', '--local'], tmpDir);
+  const apiExtractorCmd = join(process.cwd(), 'node_modules', '.bin', 'api-extractor')
+  await execaNodeAndLog(apiExtractorCmd, ['run', '--local'], tmpDir);
   await fs.copy(apiExtractorTempPath, tmpDir);
   await fs.remove(apiExtractorTempPath);
   await fs.remove(apiExtractorConfigPath);
 
   await fs.copy(join(cloudRadPath, 'api-extractor-configs'), tmpDir);
-  await execAndLog(
-    'api-documenter',
+  const apiDocumenterCmd =  join(process.cwd(), 'node_modules', '.bin', 'api-documenter')
+  await execaNodeAndLog(
+    apiDocumenterCmd,
     ['yaml', `--input-folder=${tmpDir}`, `--output-folder=${outputDir}`],
     // Use the real cwd so api-documenter can find the code samples.
     process.cwd()

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -59,7 +59,6 @@ export function replace(values, valueProp, replacerMap) {
 }
 
 export async function execaNodeAndLog(cmd, args, cwd) {
-  // const cmd = join(process.cwd(), 'node_modules', '.bin', nodeBin);
   const opts = {cwd};
 
   opts.stdout = process.stdout
@@ -69,7 +68,6 @@ export async function execaNodeAndLog(cmd, args, cwd) {
 }
 
 export async function execaAndLog(cmd, args, cwd) {
-  // const cmd = join(process.cwd(), 'node_modules', '.bin', nodeBin);
   const opts = {cwd};
 
   opts.stdout = process.stdout

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+import {execa, execaNode} from 'execa';
 import {minimatch} from 'minimatch';
 import * as url from 'url';
 
@@ -55,4 +56,24 @@ export function replace(values, valueProp, replacerMap) {
       });
     }
   });
+}
+
+export async function execaNodeAndLog(cmd, args, cwd) {
+  // const cmd = join(process.cwd(), 'node_modules', '.bin', nodeBin);
+  const opts = {cwd};
+
+  opts.stdout = process.stdout
+  opts.stderr = process.stderr
+
+  return execaNode(cmd, args, opts);
+}
+
+export async function execaAndLog(cmd, args, cwd) {
+  // const cmd = join(process.cwd(), 'node_modules', '.bin', nodeBin);
+  const opts = {cwd};
+
+  opts.stdout = process.stdout
+  opts.stderr = process.stderr
+
+  return execa(cmd, args, opts);
 }

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -59,23 +59,15 @@ export function replace(values, valueProp, replacerMap) {
 }
 
 /**
- * Executes command in a subprocess.
- *
- * @param {string} cmd The command to run in the subprocess.
- * @param {Array<string>} args Additional args to include when running the command.
- * @param {string} cwd The working directory in which to run the command.
- * @param {boolean=} isNodeCmd If set, command will be run in Node.
- * @returns A Promise containing the result of the command.
+ * Calls execa function with logs piped to parent process.
  */
-export async function execaAndLog(cmd, args, cwd, isNodeCmd = false) {
-  const opts = {cwd};
+export function withLogs(execaFn) {
+  return async function(cmd, args, cwd) {
+    const opts = {cwd};
 
-  opts.stdout = process.stdout
-  opts.stderr = process.stderr
+    opts.stdout = process.stdout;
+    opts.stderr = process.stderr;
 
-  if (isNodeCmd) {
-    return execaNode(cmd, args, opts);
-  } else {
-    return execa(cmd, args, opts);
+    return execaFn(cmd, args, opts);
   }
 }

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -58,20 +58,24 @@ export function replace(values, valueProp, replacerMap) {
   });
 }
 
-export async function execaNodeAndLog(cmd, args, cwd) {
+/**
+ * Executes command in a subprocess.
+ *
+ * @param {string} cmd The command to run in the subprocess.
+ * @param {Array<string>} args Additional args to include when running the command.
+ * @param {string} cwd The working directory in which to run the command.
+ * @param {boolean=} isNodeCmd If set, command will be run in Node.
+ * @returns A Promise containing the result of the command.
+ */
+export async function execaAndLog(cmd, args, cwd, isNodeCmd = false) {
   const opts = {cwd};
 
   opts.stdout = process.stdout
   opts.stderr = process.stderr
 
-  return execaNode(cmd, args, opts);
-}
-
-export async function execaAndLog(cmd, args, cwd) {
-  const opts = {cwd};
-
-  opts.stdout = process.stdout
-  opts.stderr = process.stderr
-
-  return execa(cmd, args, opts);
+  if (isNodeCmd) {
+    return execaNode(cmd, args, opts);
+  } else {
+    return execa(cmd, args, opts);
+  }
 }

--- a/main.mjs
+++ b/main.mjs
@@ -15,10 +15,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import {execaAndLog} from './lib/util.mjs'
+import {execa} from 'execa';
 import fs from 'fs-extra';
 import generateDevsite from './lib/generate-devsite.mjs';
 import {join} from 'path';
+import {withLogs} from './lib/util.mjs'
 
 // Creates docs.metadata, based on package.json and .repo-metadata.json.
 async function createMetadata() {
@@ -27,9 +28,9 @@ async function createMetadata() {
   const packageShortName = packageInfo.name.replace('@google-cloud/', '');
   const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
 
-  await execaAndLog('pip', ['install', '-U', 'pip'], cwd)
-  await execaAndLog('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
-  await execaAndLog('python3', [
+  await withLogs(execa)('pip', ['install', '-U', 'pip'], cwd)
+  await withLogs(execa)('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
+  await withLogs(execa)('python3', [
     '-m',
     'docuploader',
     'create-metadata',
@@ -56,7 +57,7 @@ function deploy() {
     process.env.CREDENTIALS ||
     process.env.KOKORO_KEYSTORE_DIR + '/73713_docuploader_service_account';
 
-  return execaAndLog('python3', [
+  return withLogs(execa)('python3', [
     '-m',
     'docuploader',
     'upload',

--- a/main.mjs
+++ b/main.mjs
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import {execa} from 'execa';
+import {execaAndLog} from './util.mjs'
 import fs from 'fs-extra';
 import generateDevsite from './lib/generate-devsite.mjs';
 import {join} from 'path';
@@ -27,9 +27,9 @@ async function createMetadata() {
   const packageShortName = packageInfo.name.replace('@google-cloud/', '');
   const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
 
-  await execa('pip', ['install', '-U', 'pip']);
-  await execa('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader']);
-  await execa('python3', [
+  await execaAndLog('pip', ['install', '-U', 'pip'], cwd)
+  await execaAndLog('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
+  await execaAndLog('python3', [
     '-m',
     'docuploader',
     'create-metadata',
@@ -40,7 +40,8 @@ async function createMetadata() {
     `--product-page=${repoMetadata.product_documentation}`,
     `--github-repository=${repoMetadata.repo}`,
     `--issue-tracker=${repoMetadata.issue_tracker}`,
-  ]);
+  ], cwd);
+
 
   return fs.copyFile(
     join(cwd, 'docs.metadata'),

--- a/main.mjs
+++ b/main.mjs
@@ -56,7 +56,7 @@ function deploy() {
     process.env.CREDENTIALS ||
     process.env.KOKORO_KEYSTORE_DIR + '/73713_docuploader_service_account';
 
-  return execa('python3', [
+  return execaAndLog('python3', [
     '-m',
     'docuploader',
     'upload',
@@ -67,7 +67,7 @@ function deploy() {
     credentials,
     '--staging-bucket',
     bucket,
-  ]);
+  ], process.cwd());
 }
 
 (async () => {

--- a/main.mjs
+++ b/main.mjs
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import {execaAndLog} from './util.mjs'
+import {execaAndLog} from './lib/util.mjs'
 import fs from 'fs-extra';
 import generateDevsite from './lib/generate-devsite.mjs';
 import {join} from 'path';

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -14,10 +14,9 @@
   limitations under the License.
 */
 import {basename, join} from 'path';
-import {execa} from 'execa';
+import {execaAndLog, matchesGlobs} from '../lib/util.mjs';
 import fs from 'fs-extra';
 import klaw from 'klaw';
-import {matchesGlobs} from '../lib/util.mjs';
 import os from 'os';
 
 export async function createTmpDir() {
@@ -63,9 +62,9 @@ export const mochaHooks = {
       join(process.cwd(), 'test', 'fixtures', 'nodejs-deploy'),
       nodeDeployDir
     );
-    await execa('npm', ['install'], {cwd: nodeDeployDir});
+    await execaAndLog('npm', ['install'], nodeDeployDir);
 
-    return execa('npm', ['run', 'compile'], {cwd: nodeDeployDir});
+    return execaAndLog('npm', ['run', 'compile'], nodeDeployDir);
   },
   async afterAll() {
     return removeTmpDir(mochaHooks._tmpDir);

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -14,7 +14,8 @@
   limitations under the License.
 */
 import {basename, join} from 'path';
-import {execaAndLog, matchesGlobs} from '../lib/util.mjs';
+import {execa} from 'execa';
+import {matchesGlobs, withLogs} from '../lib/util.mjs';
 import fs from 'fs-extra';
 import klaw from 'klaw';
 import os from 'os';
@@ -62,9 +63,9 @@ export const mochaHooks = {
       join(process.cwd(), 'test', 'fixtures', 'nodejs-deploy'),
       nodeDeployDir
     );
-    await execaAndLog('npm', ['install'], nodeDeployDir);
+    await withLogs(execa)('npm', ['install'], nodeDeployDir);
 
-    return execaAndLog('npm', ['run', 'compile'], nodeDeployDir);
+    return withLogs(execa)('npm', ['run', 'compile'], nodeDeployDir);
   },
   async afterAll() {
     return removeTmpDir(mochaHooks._tmpDir);


### PR DESCRIPTION
This changes ensures that logs are output from the child process that execa produces.
