### PR TITLE
test: create snippet bot config to ignore test files

### DIFF
--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -1,3 +1,3 @@
 ignoreFiles:
   - test/fixtures/**/*
-  - test/fixtures/**/*
+  - test/specs/lib/**/*

--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -1,0 +1,3 @@
+ignoreFiles:
+  - test/fixtures/**/*
+  - test/fixtures/**/*


### PR DESCRIPTION
This is to ignore region tags contained in our test library.

Note: The commit a [skip ci] tag to skip our tests. Fixes will be submitted as follow-up in #93 once the snippets are no longer registered.