### PR TITLE
fix: update package short name to apply to non cloud namespaces

### DIFF
--- a/__snapshots__/generate-devsite.mjs.js
+++ b/__snapshots__/generate-devsite.mjs.js
@@ -321,6 +321,10 @@ items:
                 uid: '@google-cloud/deploy!protos.google.protobuf.ExtensionRangeOptions:class'
               - name: FeatureSet
                 uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet:class'
+              - name: FeatureSetDefaults
+                uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults:class'
+              - name: FeatureSetEditionDefault
+                uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault:class'
               - name: FieldDescriptorProto
                 uid: '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto:class'
               - name: FieldMask
@@ -677,6 +681,10 @@ items:
                 uid: '@google-cloud/deploy!protos.google.protobuf.IExtensionRangeOptions:interface'
               - name: IFeatureSet
                 uid: '@google-cloud/deploy!protos.google.protobuf.IFeatureSet:interface'
+              - name: IFeatureSetDefaults
+                uid: '@google-cloud/deploy!protos.google.protobuf.IFeatureSetDefaults:interface'
+              - name: IFeatureSetEditionDefault
+                uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault:interface'
               - name: IFieldDescriptorProto
                 uid: '@google-cloud/deploy!protos.google.protobuf.IFieldDescriptorProto:interface'
               - name: IFieldMask
@@ -779,6 +787,8 @@ items:
             items:
               - name: CType
                 uid: '@google-cloud/deploy!protos.google.protobuf.FieldOptions.CType:enum'
+              - name: Edition
+                uid: '@google-cloud/deploy!protos.google.protobuf.Edition:enum'
               - name: EnumType
                 uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.EnumType:enum'
               - name: FieldPresence
@@ -803,10 +813,10 @@ items:
                 uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.RepeatedFieldEncoding:enum'
               - name: Semantic
                 uid: '@google-cloud/deploy!protos.google.protobuf.GeneratedCodeInfo.Annotation.Semantic:enum'
-              - name: StringFieldValidation
-                uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.StringFieldValidation:enum'
               - name: Type
                 uid: '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto.Type:enum'
+              - name: Utf8Validation
+                uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.Utf8Validation:enum'
               - name: VerificationState
                 uid: '@google-cloud/deploy!protos.google.protobuf.ExtensionRangeOptions.VerificationState:enum'
 
@@ -1378,6 +1388,7 @@ items:
       - '@google-cloud/deploy!protos.google.protobuf.DescriptorProto.IReservedRange:interface'
       - '@google-cloud/deploy!protos.google.protobuf.DescriptorProto.ReservedRange:class'
       - '@google-cloud/deploy!protos.google.protobuf.Duration:class'
+      - '@google-cloud/deploy!protos.google.protobuf.Edition:enum'
       - '@google-cloud/deploy!protos.google.protobuf.Empty:class'
       - '@google-cloud/deploy!protos.google.protobuf.EnumDescriptorProto:class'
       - '@google-cloud/deploy!protos.google.protobuf.EnumDescriptorProto.EnumReservedRange:class'
@@ -1395,7 +1406,10 @@ items:
       - '@google-cloud/deploy!protos.google.protobuf.FeatureSet.JsonFormat:enum'
       - '@google-cloud/deploy!protos.google.protobuf.FeatureSet.MessageEncoding:enum'
       - '@google-cloud/deploy!protos.google.protobuf.FeatureSet.RepeatedFieldEncoding:enum'
-      - '@google-cloud/deploy!protos.google.protobuf.FeatureSet.StringFieldValidation:enum'
+      - '@google-cloud/deploy!protos.google.protobuf.FeatureSet.Utf8Validation:enum'
+      - '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults:class'
+      - '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault:class'
+      - '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault:interface'
       - '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto:class'
       - '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto.Label:enum'
       - '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto.Type:enum'
@@ -1425,6 +1439,7 @@ items:
       - '@google-cloud/deploy!protos.google.protobuf.IEnumValueOptions:interface'
       - '@google-cloud/deploy!protos.google.protobuf.IExtensionRangeOptions:interface'
       - '@google-cloud/deploy!protos.google.protobuf.IFeatureSet:interface'
+      - '@google-cloud/deploy!protos.google.protobuf.IFeatureSetDefaults:interface'
       - '@google-cloud/deploy!protos.google.protobuf.IFieldDescriptorProto:interface'
       - '@google-cloud/deploy!protos.google.protobuf.IFieldMask:interface'
       - '@google-cloud/deploy!protos.google.protobuf.IFieldOptions:interface'
@@ -3033,6 +3048,8 @@ references:
     name: protos.google.protobuf.DescriptorProto.ReservedRange
   - uid: '@google-cloud/deploy!protos.google.protobuf.Duration:class'
     name: protos.google.protobuf.Duration
+  - uid: '@google-cloud/deploy!protos.google.protobuf.Edition:enum'
+    name: protos.google.protobuf.Edition
   - uid: '@google-cloud/deploy!protos.google.protobuf.Empty:class'
     name: protos.google.protobuf.Empty
   - uid: '@google-cloud/deploy!protos.google.protobuf.EnumDescriptorProto:class'
@@ -3067,8 +3084,14 @@ references:
     name: protos.google.protobuf.FeatureSet.MessageEncoding
   - uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.RepeatedFieldEncoding:enum'
     name: protos.google.protobuf.FeatureSet.RepeatedFieldEncoding
-  - uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.StringFieldValidation:enum'
-    name: protos.google.protobuf.FeatureSet.StringFieldValidation
+  - uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSet.Utf8Validation:enum'
+    name: protos.google.protobuf.FeatureSet.Utf8Validation
+  - uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults:class'
+    name: protos.google.protobuf.FeatureSetDefaults
+  - uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault:class'
+    name: protos.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault
+  - uid: '@google-cloud/deploy!protos.google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault:interface'
+    name: protos.google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault
   - uid: '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto:class'
     name: protos.google.protobuf.FieldDescriptorProto
   - uid: '@google-cloud/deploy!protos.google.protobuf.FieldDescriptorProto.Label:enum'
@@ -3127,6 +3150,8 @@ references:
     name: protos.google.protobuf.IExtensionRangeOptions
   - uid: '@google-cloud/deploy!protos.google.protobuf.IFeatureSet:interface'
     name: protos.google.protobuf.IFeatureSet
+  - uid: '@google-cloud/deploy!protos.google.protobuf.IFeatureSetDefaults:interface'
+    name: protos.google.protobuf.IFeatureSetDefaults
   - uid: '@google-cloud/deploy!protos.google.protobuf.IFieldDescriptorProto:interface'
     name: protos.google.protobuf.IFieldDescriptorProto
   - uid: '@google-cloud/deploy!protos.google.protobuf.IFieldMask:interface'

--- a/lib/generate-devsite.mjs
+++ b/lib/generate-devsite.mjs
@@ -19,6 +19,7 @@ import {fileURLToPath, URL} from 'url';
 import fs from 'fs-extra';
 import generateYaml from './generate-yaml.mjs';
 import {join} from 'path';
+import {packageShortNameRegex} from './util.mjs';
 import processYaml from './process-yaml.mjs';
 
 const SHARED_PACKAGES = ['@google-cloud/common', 'google-auth-library'];
@@ -28,7 +29,7 @@ export default async function generate(opts = {}) {
   const cwd = opts.cwd || process.cwd();
   const packageInfo = await fs.readJson(join(cwd, 'package.json'));
   const isSharedPackage = SHARED_PACKAGES.includes(packageInfo.name);
-  const packageShortName = packageInfo.name.replace('@google-cloud/', '');
+  const packageShortName = packageInfo.name.replace(packageShortNameRegex, '');
   const tmpDir = (opts.tmpDir = await fs.mkdtemp(join(cwd, 'cloud-rad-')));
   const metadata = {
     cloudRadPath,

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -18,6 +18,7 @@ import {minimatch} from 'minimatch';
 import * as url from 'url';
 
 export const cloudRadDir = url.fileURLToPath(new URL('..', import.meta.url));
+export const packageShortNameRegex = /@google-[^\/]+\//g
 
 export function matchesGlobs(filepath, globPatterns) {
   for (const pattern of globPatterns) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/test/specs/lib/generate-devsite.mjs
+++ b/test/specs/lib/generate-devsite.mjs
@@ -19,6 +19,7 @@ import fs from 'fs-extra';
 import generateDevsite from '../../../lib/generate-devsite.mjs';
 import {mochaHooks} from '../../helpers.mjs';
 import {join} from 'path';
+import {packageShortNameRegex} from '../../../lib/util.mjs';
 import snapshots from '../../../__snapshots__/generate-devsite.mjs.js';
 import takeSnapshot from 'snap-shot-it';
 
@@ -40,7 +41,7 @@ before(async () => {
   const packageInfo = await fs.readJson(
     join(mochaHooks.googleCloudDeployDir, 'package.json')
   );
-  const packageShortName = packageInfo.name.replace('@google-cloud/', '');
+  const packageShortName = packageInfo.name.replace(packageShortNameRegex, '');
 
   return generateDevsite({
     cwd,

--- a/test/specs/lib/util.mjs
+++ b/test/specs/lib/util.mjs
@@ -14,4 +14,17 @@
   limitations under the License.
 */
 
-// This module is tested by other modules' tests.
+import {strict as assert} from 'assert';
+import {packageShortNameRegex} from '../../../lib/util.mjs';
+
+describe('package short name regex', () => {
+  it('matches @google-cloud namespace', async () => {
+    const googleCloudPackageName = '@google-cloud/retail'
+    assert.deepEqual(googleCloudPackageName.match(packageShortNameRegex), ['@google-cloud/'])
+  });
+
+  it('matches other @google namespaces', async () => {
+    const googleCloudPackageName = '@google-apps/meet'
+    assert.deepEqual(googleCloudPackageName.match(packageShortNameRegex), ['@google-apps/'])
+  });
+})


### PR DESCRIPTION
I tested this by generating docs for @google-apps/meet locally using a debug release: [0.4.11-debug](https://www.npmjs.com/package/@google-cloud/cloud-rad/v/0.4.11-debug).

Will follow up with release.

