### PR TITLE
fix: ensure docs.metadata file uses package short name

### DIFF
--- a/__snapshots__/metadata.mjs.js
+++ b/__snapshots__/metadata.mjs.js
@@ -1,0 +1,21 @@
+exports['docs.metadata generation generates for google-cloud libraries 1'] = `
+name: "deploy"
+version: "3.0.1"
+language: "nodejs"
+distribution_name: "@google-cloud/deploy"
+product_page: "https://cloud.google.com/deploy/"
+github_repository: "googleapis/google-cloud-node"
+issue_tracker: "https://github.com/googleapis/google-cloud-node/issues"
+
+`
+
+exports['docs.metadata generation generates for non-cloud libraries 1'] = `
+name: "meet"
+version: "0.2.0"
+language: "nodejs"
+distribution_name: "@google-apps/meet"
+product_page: "https://developers.google.com/meet/api/guides/overview"
+github_repository: "googleapis/google-cloud-node"
+issue_tracker: "https://github.com/googleapis/google-cloud-node/issues"
+
+`

--- a/lib/generate-devsite.mjs
+++ b/lib/generate-devsite.mjs
@@ -18,8 +18,8 @@ import copyYaml from './copy-yaml.mjs';
 import {fileURLToPath, URL} from 'url';
 import fs from 'fs-extra';
 import generateYaml from './generate-yaml.mjs';
+import {getPackageShortName} from './util.mjs';
 import {join} from 'path';
-import {packageShortNameRegex} from './util.mjs';
 import processYaml from './process-yaml.mjs';
 
 const SHARED_PACKAGES = ['@google-cloud/common', 'google-auth-library'];
@@ -29,7 +29,7 @@ export default async function generate(opts = {}) {
   const cwd = opts.cwd || process.cwd();
   const packageInfo = await fs.readJson(join(cwd, 'package.json'));
   const isSharedPackage = SHARED_PACKAGES.includes(packageInfo.name);
-  const packageShortName = packageInfo.name.replace(packageShortNameRegex, '');
+  const packageShortName = getPackageShortName(packageInfo.name);
   const tmpDir = (opts.tmpDir = await fs.mkdtemp(join(cwd, 'cloud-rad-')));
   const metadata = {
     cloudRadPath,

--- a/lib/metadata.mjs
+++ b/lib/metadata.mjs
@@ -45,7 +45,7 @@ export default async function createMetadata(opts = {}) {
   if (cwd != destination) {
     return fs.copyFile(
         join(cwd, 'docs.metadata'),
-        destination
+        join(destination, 'docs.metadata')
       ); 
   }
 }

--- a/lib/metadata.mjs
+++ b/lib/metadata.mjs
@@ -15,16 +15,16 @@
 */
 
 import {execa} from 'execa';
+import {getPackageShortName, withLogs} from './util.mjs'
 import fs from 'fs-extra';
 import {join} from 'path';
-import {packageShortNameRegex, withLogs} from './util.mjs'
 
 // Creates docs.metadata, based on package.json and .repo-metadata.json.
 export default async function createMetadata(opts = {}) {
   const cwd = opts.cwd || process.cwd();
   const destination = opts.destination || join(process.cwd(), '_devsite'); 
   const packageInfo = await fs.readJson(join(cwd, 'package.json'));
-  const packageShortName = packageInfo.name.replace(packageShortNameRegex, '');
+  const packageShortName = getPackageShortName(packageInfo.name);
   const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
 
   await withLogs(execa)('pip', ['install', '-U', 'pip'], cwd)

--- a/lib/metadata.mjs
+++ b/lib/metadata.mjs
@@ -1,0 +1,51 @@
+/*
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {execa} from 'execa';
+import fs from 'fs-extra';
+import {join} from 'path';
+import {packageShortNameRegex, withLogs} from './util.mjs'
+
+// Creates docs.metadata, based on package.json and .repo-metadata.json.
+export default async function createMetadata(opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const destination = opts.destination || join(process.cwd(), '_devsite'); 
+  const packageInfo = await fs.readJson(join(cwd, 'package.json'));
+  const packageShortName = packageInfo.name.replace(packageShortNameRegex, '');
+  const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
+
+  await withLogs(execa)('pip', ['install', '-U', 'pip'], cwd)
+  await withLogs(execa)('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
+  await withLogs(execa)('python3', [
+    '-m',
+    'docuploader',
+    'create-metadata',
+    `--name=${packageShortName}`,
+    `--version=${packageInfo.version}`,
+    `--language=${repoMetadata.language}`,
+    `--distribution-name=${repoMetadata.distribution_name}`,
+    `--product-page=${repoMetadata.product_documentation}`,
+    `--github-repository=${repoMetadata.repo}`,
+    `--issue-tracker=${repoMetadata.issue_tracker}`,
+  ], cwd);
+
+  if (cwd != destination) {
+    return fs.copyFile(
+        join(cwd, 'docs.metadata'),
+        destination
+      ); 
+  }
+}

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -87,8 +87,8 @@ export function withLogs(execaFn) {
 export function getPackageShortName(packageName) {
   const packageShortNameRegex = /@google[^\/]+\//g
 
-  const hasCloudNamespace = packageShortNameRegex.test(packageName)
-  if (!hasCloudNamespace) {
+  const hasGoogleNamespace = packageShortNameRegex.test(packageName)
+  if (!hasGoogleNamespace) {
     throw new Error('Package ' + packageName + ' does not have required "@google" prefix.')
   }
 

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -18,7 +18,6 @@ import {minimatch} from 'minimatch';
 import * as url from 'url';
 
 export const cloudRadDir = url.fileURLToPath(new URL('..', import.meta.url));
-export const packageShortNameRegex = /@google-[^\/]+\//g
 
 export function matchesGlobs(filepath, globPatterns) {
   for (const pattern of globPatterns) {
@@ -80,4 +79,18 @@ export function withLogs(execaFn) {
 
     return execaFn(cmd, args, opts);
   };
+}
+
+/**
+ * Retrieves the package short name by removing the namespace prefix for Google libraries.
+ */
+export function getPackageShortName(packageName) {
+  const packageShortNameRegex = /@google-[^\/]+\//g
+
+  const hasCloudNamespace = packageShortNameRegex.test(packageName)
+  if (!hasCloudNamespace) {
+    throw new Error('Package does not have required namespace prefix.')
+  }
+
+  return packageName.replace(packageShortNameRegex, '');
 }

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -85,11 +85,11 @@ export function withLogs(execaFn) {
  * Retrieves the package short name by removing the namespace prefix for Google libraries.
  */
 export function getPackageShortName(packageName) {
-  const packageShortNameRegex = /@google-[^\/]+\//g
+  const packageShortNameRegex = /@google[^\/]+\//g
 
   const hasCloudNamespace = packageShortNameRegex.test(packageName)
   if (!hasCloudNamespace) {
-    throw new Error('Package ' + packageName + ' does not have required "/@google-" prefix.')
+    throw new Error('Package ' + packageName + ' does not have required "@google" prefix.')
   }
 
   return packageName.replace(packageShortNameRegex, '');

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -89,7 +89,7 @@ export function getPackageShortName(packageName) {
 
   const hasCloudNamespace = packageShortNameRegex.test(packageName)
   if (!hasCloudNamespace) {
-    throw new Error('Package does not have required namespace prefix.')
+    throw new Error('Package ' + packageName + ' does not have required "/@google-" prefix.')
   }
 
   return packageName.replace(packageShortNameRegex, '');

--- a/main.mjs
+++ b/main.mjs
@@ -17,39 +17,9 @@
 */
 
 import {execa} from 'execa';
-import fs from 'fs-extra';
+import createMetadata from './lib/metadata.mjs';
 import generateDevsite from './lib/generate-devsite.mjs';
-import {join} from 'path';
 import {withLogs} from './lib/util.mjs'
-
-// Creates docs.metadata, based on package.json and .repo-metadata.json.
-async function createMetadata() {
-  const cwd = process.cwd();
-  const packageInfo = await fs.readJson(join(cwd, 'package.json'));
-  const packageShortName = packageInfo.name.replace('@google-cloud/', '');
-  const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
-
-  await withLogs(execa)('pip', ['install', '-U', 'pip'], cwd)
-  await withLogs(execa)('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
-  await withLogs(execa)('python3', [
-    '-m',
-    'docuploader',
-    'create-metadata',
-    `--name=${packageShortName}`,
-    `--version=${packageInfo.version}`,
-    `--language=${repoMetadata.language}`,
-    `--distribution-name=${repoMetadata.distribution_name}`,
-    `--product-page=${repoMetadata.product_documentation}`,
-    `--github-repository=${repoMetadata.repo}`,
-    `--issue-tracker=${repoMetadata.issue_tracker}`,
-  ], cwd);
-
-
-  return fs.copyFile(
-    join(cwd, 'docs.metadata'),
-    join(cwd, '_devsite', 'docs.metadata')
-  );
-}
 
 // Deploys the docs.
 function deploy() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
@@ -11,7 +11,7 @@
     "coverage": "c8 npm run test",
     "test": "env TEST=1 mocha --timeout=50000 --require './test/helpers.mjs' --recursive './test/specs/**/*.mjs'",
     "update-api-model": "api-extractor run --local -c ./test/fixtures/api-model/api-extractor.json",
-    "update-snapshots": "env SNAPSHOT_UPDATE=1 TEST=1 mocha --timeout=50000 --require './test/helpers.mjs' './test/specs/lib/generate-devsite.mjs'"
+    "update-snapshots": "env SNAPSHOT_UPDATE=1 TEST=1 mocha --timeout=50000 --require './test/helpers.mjs' './test/specs/lib/generate-devsite.mjs' './test/specs/lib/metadata.mjs'"
   },
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/test/fixtures/google-apps-meet/.repo-metadata.json
+++ b/test/fixtures/google-apps-meet/.repo-metadata.json
@@ -1,0 +1,17 @@
+{
+  "name": "meet",
+  "name_pretty": "Google Meet API",
+  "product_documentation": "https://developers.google.com/meet/api/guides/overview",
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/meet/latest",
+  "issue_tracker": "https://github.com/googleapis/google-cloud-node/issues",
+  "release_level": "preview",
+  "language": "nodejs",
+  "repo": "googleapis/google-cloud-node",
+  "distribution_name": "@google-apps/meet",
+  "api_id": "meet.googleapis.com",
+  "default_version": "v2",
+  "requires_billing": true,
+  "library_type": "GAPIC_AUTO",
+  "api_shortname": "meet"
+}
+

--- a/test/fixtures/google-apps-meet/package.json
+++ b/test/fixtures/google-apps-meet/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@google-apps/meet",
+  "version": "0.2.0",
+  "description": "Google Meet API client for Node.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/google-cloud-node.git",
+    "directory": "packages/google-apps-meet"
+  },
+  "license": "Apache-2.0",
+  "author": "Google LLC",
+  "main": "build/src/index.js",
+  "files": [
+    "build/src",
+    "build/protos"
+  ],
+  "homepage": "https://github.com/googleapis/google-cloud-node/tree/main/packages/google-apps-meet",
+  "keywords": [
+    "google apis client",
+    "google api client",
+    "google apis",
+    "google api",
+    "google",
+    "google cloud platform",
+    "google cloud",
+    "cloud",
+    "google meet",
+    "meet",
+    "Google Meet API"
+  ],
+  "scripts": {
+    "clean": "gts clean",
+    "compile": "tsc -p . && cp -r protos build/",
+    "compile-protos": "compileProtos src",
+    "docs": "jsdoc -c .jsdoc.js",
+    "predocs-test": "npm run docs",
+    "docs-test": "linkinator docs",
+    "fix": "gts fix",
+    "lint": "gts check",
+    "postpack": "minifyProtoJson",
+    "prepare": "npm run compile",
+    "system-test": "c8 mocha build/system-test",
+    "test": "c8 mocha build/test",
+    "samples-test": "cd samples/ && npm link ../ && npm i && npm test",
+    "prelint": "cd samples; npm link ../; npm i"
+  },
+  "dependencies": {
+    "google-gax": "^4.0.3"
+  },
+  "devDependencies": {
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^20.4.5",
+    "@types/sinon": "^17.0.0",
+    "c8": "^8.0.1",
+    "gapic-tools": "^0.4.0",
+    "gts": "^5.0.0",
+    "jsdoc": "^4.0.0",
+    "jsdoc-fresh": "^3.0.0",
+    "jsdoc-region-tag": "^3.0.0",
+    "linkinator": "4.1.2",
+    "long": "^5.2.3",
+    "mocha": "^9.2.2",
+    "pack-n-play": "^2.0.0",
+    "sinon": "^17.0.0",
+    "typescript": "^5.1.6"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/test/specs/lib/generate-devsite.mjs
+++ b/test/specs/lib/generate-devsite.mjs
@@ -17,9 +17,9 @@
 import {strict as assert} from 'assert';
 import fs from 'fs-extra';
 import generateDevsite from '../../../lib/generate-devsite.mjs';
+import {getPackageShortName} from '../../../lib/util.mjs';
 import {mochaHooks} from '../../helpers.mjs';
 import {join} from 'path';
-import {packageShortNameRegex} from '../../../lib/util.mjs';
 import snapshots from '../../../__snapshots__/generate-devsite.mjs.js';
 import takeSnapshot from 'snap-shot-it';
 
@@ -41,7 +41,7 @@ before(async () => {
   const packageInfo = await fs.readJson(
     join(mochaHooks.googleCloudDeployDir, 'package.json')
   );
-  const packageShortName = packageInfo.name.replace(packageShortNameRegex, '');
+  const packageShortName = getPackageShortName(packageInfo.name);
 
   return generateDevsite({
     cwd,

--- a/test/specs/lib/metadata.mjs
+++ b/test/specs/lib/metadata.mjs
@@ -1,0 +1,83 @@
+/*
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import createMetadata from '../../../lib/metadata.mjs';
+import fs from 'fs-extra';
+import {join} from 'path';
+import {mochaHooks, createTmpDir} from '../../helpers.mjs';
+import snapshots from '../../../__snapshots__/metadata.mjs.js';
+import {strict as assert} from 'assert';
+import takeSnapshot from 'snap-shot-it';
+
+let checkSnapshot = () => {};
+const removeTimestamp = docsMetadata => {
+    const lines = docsMetadata.split('\n');
+    const snapshotLines = lines.slice(4).join('\n');
+    return snapshotLines;
+}
+
+before(async () => {
+    if (!process.env.SNAPSHOT_UPDATE) {
+      // We want to compare the output with the snapshots, not update snapshots.
+      checkSnapshot = snapshot => {
+        // The saved snapshot starts and ends with extra newline characters.
+        const value = `\n${snapshot.value}\n`;
+  
+        assert.deepStrictEqual(value, snapshots[snapshot.key]);
+      };
+    }
+});
+
+describe('docs.metadata generation', () => {
+    it('generates for google-cloud libraries', async () => {
+        const cwd = mochaHooks.googleCloudDeployDir;
+        const destination = cwd;
+        await createMetadata({
+            cwd, 
+            destination,
+        });
+
+        const docsMetadata = await fs.readFile(
+            join(mochaHooks.googleCloudDeployDir, 'docs.metadata'),
+            'utf8'
+        );
+        const snapshot = takeSnapshot(removeTimestamp(docsMetadata));
+
+        checkSnapshot(snapshot);
+    });
+
+    it('generates for non-cloud libraries', async () => {
+        const tmpDir = await createTmpDir();
+
+        const googleMeetsDir = join(process.cwd(), 'test', 'fixtures', 'google-apps-meet');
+        await fs.copy(googleMeetsDir, tmpDir);
+
+        const cwd = tmpDir
+        const destination = cwd;
+        await createMetadata({
+            cwd, 
+            destination,
+        });
+
+        const docsMetadata = await fs.readFile(
+            join(tmpDir, 'docs.metadata'),
+            'utf8'
+        );
+        const snapshot = takeSnapshot(removeTimestamp(docsMetadata))
+
+        checkSnapshot(snapshot);
+    });    
+});

--- a/test/specs/lib/util.mjs
+++ b/test/specs/lib/util.mjs
@@ -25,9 +25,9 @@ describe('get package short name', () => {
   });
 
   it('shortens other @google namespaces', async () => {
-    const googleCloudPackageName = '@google-apps/meet'
+    const googleCloudPackageName = '@googlemaps/places'
     const result = getPackageShortName(googleCloudPackageName)
-    assert.deepEqual(result, 'meet')
+    assert.deepEqual(result, 'places')
   });
 
   it('raises an error for non-Google namespaces', async () => {
@@ -35,4 +35,5 @@ describe('get package short name', () => {
 
     assert.throws(() => getPackageShortName(nonGoogleCloudPackageName), Error)
   });
+  
 })

--- a/test/specs/lib/util.mjs
+++ b/test/specs/lib/util.mjs
@@ -14,17 +14,25 @@
   limitations under the License.
 */
 
+import {getPackageShortName} from '../../../lib/util.mjs';
 import {strict as assert} from 'assert';
-import {packageShortNameRegex} from '../../../lib/util.mjs';
 
-describe('package short name regex', () => {
-  it('matches @google-cloud namespace', async () => {
+describe('get package short name', () => {
+  it('shortens @google-cloud namespace', async () => {
     const googleCloudPackageName = '@google-cloud/retail'
-    assert.deepEqual(googleCloudPackageName.match(packageShortNameRegex), ['@google-cloud/'])
+    const result = getPackageShortName(googleCloudPackageName)
+    assert.deepEqual(result, 'retail')
   });
 
-  it('matches other @google namespaces', async () => {
+  it('shortens other @google namespaces', async () => {
     const googleCloudPackageName = '@google-apps/meet'
-    assert.deepEqual(googleCloudPackageName.match(packageShortNameRegex), ['@google-apps/'])
+    const result = getPackageShortName(googleCloudPackageName)
+    assert.deepEqual(result, 'meet')
+  });
+
+  it('raises an error for non-Google namespaces', async () => {
+    const nonGoogleCloudPackageName = '@other-namespace/app'
+
+    assert.throws(() => getPackageShortName(nonGoogleCloudPackageName), Error)
   });
 })


### PR DESCRIPTION
This change has a light refactor our metadata generation (it is moved over to a separate file for testing). This also makes sure non-Cloud packages have their namespace removed for the `docs.metadata` file.

Bug: 335319822
