### PR TITLE
feat: allow clients to specify custom stem for docs.metadata

### DIFF
--- a/__snapshots__/metadata.mjs.js
+++ b/__snapshots__/metadata.mjs.js
@@ -19,3 +19,15 @@ github_repository: "googleapis/google-cloud-node"
 issue_tracker: "https://github.com/googleapis/google-cloud-node/issues"
 
 `
+
+exports['docs.metadata generation generates with custom stem 1'] = `
+name: "meet"
+version: "0.2.0"
+language: "nodejs"
+distribution_name: "@google-apps/meet"
+product_page: "https://developers.google.com/meet/api/guides/overview"
+github_repository: "googleapis/google-cloud-node"
+issue_tracker: "https://github.com/googleapis/google-cloud-node/issues"
+stem: "/package/custom/stem"
+
+`

--- a/lib/metadata.mjs
+++ b/lib/metadata.mjs
@@ -19,17 +19,8 @@ import {getPackageShortName, withLogs} from './util.mjs'
 import fs from 'fs-extra';
 import {join} from 'path';
 
-// Creates docs.metadata, based on package.json and .repo-metadata.json.
-export default async function createMetadata(opts = {}) {
-  const cwd = opts.cwd || process.cwd();
-  const destination = opts.destination || join(process.cwd(), '_devsite'); 
-  const packageInfo = await fs.readJson(join(cwd, 'package.json'));
-  const packageShortName = getPackageShortName(packageInfo.name);
-  const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
-
-  await withLogs(execa)('pip', ['install', '-U', 'pip'], cwd)
-  await withLogs(execa)('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
-  await withLogs(execa)('python3', [
+function getDocuploaderCommand(packageInfo, packageShortName, repoMetadata, stem) {
+  const docuploaderCommand = [
     '-m',
     'docuploader',
     'create-metadata',
@@ -40,7 +31,27 @@ export default async function createMetadata(opts = {}) {
     `--product-page=${repoMetadata.product_documentation}`,
     `--github-repository=${repoMetadata.repo}`,
     `--issue-tracker=${repoMetadata.issue_tracker}`,
-  ], cwd);
+  ]
+
+  if (stem) {
+    docuploaderCommand.push(`--stem=${stem}`)
+  }
+
+  return docuploaderCommand
+}
+
+// Creates docs.metadata, based on package.json and .repo-metadata.json.
+export default async function createMetadata(opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const destination = opts.destination || join(process.cwd(), '_devsite');
+  const stem = opts.stem || process.env.DOCS_METADATA_STEM;
+  const packageInfo = await fs.readJson(join(cwd, 'package.json'));
+  const packageShortName = getPackageShortName(packageInfo.name);
+  const repoMetadata = await fs.readJson(join(cwd, '.repo-metadata.json'));
+
+  await withLogs(execa)('pip', ['install', '-U', 'pip'], cwd)
+  await withLogs(execa)('python3', ['-m', 'pip', 'install', '--user', 'gcp-docuploader'], cwd)
+  await withLogs(execa)('python3', getDocuploaderCommand(packageInfo, packageShortName, repoMetadata, stem), cwd);
 
   if (cwd != destination) {
     return fs.copyFile(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/test/specs/lib/metadata.mjs
+++ b/test/specs/lib/metadata.mjs
@@ -79,5 +79,29 @@ describe('docs.metadata generation', () => {
         const snapshot = takeSnapshot(removeTimestamp(docsMetadata))
 
         checkSnapshot(snapshot);
-    });    
+    });
+
+    it('generates with custom stem', async () => {
+        const tmpDir = await createTmpDir();
+
+        const googleMeetsDir = join(process.cwd(), 'test', 'fixtures', 'google-apps-meet');
+        await fs.copy(googleMeetsDir, tmpDir);
+
+        const cwd = tmpDir
+        const destination = cwd;
+        const stem = '/package/custom/stem'
+        await createMetadata({
+            cwd,
+            destination,
+            stem,
+        });
+
+        const docsMetadata = await fs.readFile(
+            join(tmpDir, 'docs.metadata'),
+            'utf8'
+        );
+        const snapshot = takeSnapshot(removeTimestamp(docsMetadata))
+
+        checkSnapshot(snapshot);
+    });
 });


### PR DESCRIPTION
Towards b/339671214.

This allows clients to provide an environmental variable `DOCS_METADATA_STEM` to specify a custom stem to be included in the generated `docs.metadata` file.