### PR TITLE
fix(deps): pin api-extractor-model to last known working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
@@ -18,7 +18,7 @@
   "dependencies": {
     "@googleapis/api-documenter": "~7.13.0",
     "@microsoft/api-extractor": "~7.40.0",
-    "@microsoft/api-extractor-model": "^7.27.2",
+    "@microsoft/api-extractor-model": "7.28.13",
     "@rushstack/node-core-library": "^3.55.2",
     "execa": "^7.0.0",
     "fs-extra": "^11.1.0",
@@ -30,7 +30,6 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "ajv": "^8.14.0",
     "c8": "^9.0.0",
     "eslint": "^8.32.0",
     "gts": "^5.0.0",


### PR DESCRIPTION
Temporarily pins @microsoft/api-extractor-model to v7.28.13. I've tried bumping both @microsoft/api-extractor-model and @microsoft/api-extractor to latest versions, but still see: "Error: Cannot find module 'ajv/dist/core'". Will continue to debug, but want to unblock publishing for now.

Fixes #115 
