### PR TITLE
build: add "ajv" dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
@@ -30,6 +30,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "c8": "^9.0.0",
     "eslint": "^8.32.0",
     "gts": "^5.0.0",


### PR DESCRIPTION
Tests seem to be failing with this missing dependency. Added this back in, ran locally, and  they pass again.
