### PR TITLE
build(deps): cap api-extractor-model to 7.28.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",
@@ -18,8 +18,9 @@
   "dependencies": {
     "@googleapis/api-documenter": "~7.13.0",
     "@microsoft/api-extractor": "~7.40.0",
-    "@microsoft/api-extractor-model": "7.29.8",
+    "@microsoft/api-extractor-model": "<7.28.13",
     "@rushstack/node-core-library": "^3.55.2",
+    "ajv": "^8.17.1",
     "execa": "^7.0.0",
     "fs-extra": "^11.1.0",
     "glob": "^10.1.0",
@@ -30,7 +31,6 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "ajv": "^8.17.1",
     "c8": "^9.0.0",
     "eslint": "^8.32.0",
     "gts": "^5.0.0",


### PR DESCRIPTION
The version got updated which is causing a dependency issue. Also, ajv as a dev dependency doesn't seem sufficient, so I moved it to a regular dep.

I tested this with a debug version, which was able to generate docs locally: https://www.npmjs.com/package/@google-cloud/cloud-rad/v/0.4.72-debug

Towards  #131 