### PR TITLE
fix: add support for CommonJs build directory

### DIFF
--- a/__snapshots__/generate-devsite.mjs.js
+++ b/__snapshots__/generate-devsite.mjs.js
@@ -14103,3 +14103,107 @@ references:
     name: $protobuf.IConversionOptions
 
 `
+
+exports['cloud-rad supports CommonJS build for docs entry point generates an overview.yml file 1'] = `
+### YamlMime:UniversalReference
+items:
+  - uid: '@google-cloud/deploy!'
+    name: '@google-cloud/deploy'
+    fullName: '@google-cloud/deploy'
+    langs:
+      - typeScript
+    type: package
+    children:
+      - '@google-cloud/deploy!_default:var'
+      - '@google-cloud/deploy!CloudDeployClient:type'
+      - '@google-cloud/deploy!CloudDeployClient:var'
+      - '@google-cloud/deploy!v1.CloudDeployClient:class'
+  - uid: '@google-cloud/deploy!_default:var'
+    name: _default
+    fullName: _default
+    langs:
+      - typeScript
+    type: variable
+    syntax:
+      content: |-
+        _default: {
+            v1: typeof v1;
+            CloudDeployClient: typeof v1.CloudDeployClient;
+        }
+      return:
+        type:
+          - '@google-cloud/deploy!_default~0:complex'
+  - uid: '@google-cloud/deploy!CloudDeployClient:type'
+    name: CloudDeployClient
+    fullName: CloudDeployClient
+    langs:
+      - typeScript
+    type: typealias
+    syntax:
+      content: type CloudDeployClient = v1.CloudDeployClient;
+      return:
+        type:
+          - '@google-cloud/deploy!v1.CloudDeployClient_2:class'
+  - uid: '@google-cloud/deploy!CloudDeployClient:var'
+    name: CloudDeployClient
+    fullName: CloudDeployClient
+    langs:
+      - typeScript
+    type: variable
+    syntax:
+      content: 'CloudDeployClient: typeof v1.CloudDeployClient'
+      return:
+        type:
+          - '@google-cloud/deploy!CloudDeployClient~0:complex'
+references:
+  - uid: '@google-cloud/deploy!_default~0:complex'
+    name: |-
+      {
+          v1: typeof v1;
+          CloudDeployClient: typeof v1.CloudDeployClient;
+      }
+    fullName: |-
+      {
+          v1: typeof v1;
+          CloudDeployClient: typeof v1.CloudDeployClient_2;
+      }
+    spec.typeScript:
+      - name: |-
+          {
+              v1: typeof 
+        fullName: |-
+          {
+              v1: typeof 
+      - uid: '@google-cloud/deploy!v1'
+        name: v1
+        fullName: v1
+      - name: |-
+          ;
+              CloudDeployClient: typeof 
+        fullName: |-
+          ;
+              CloudDeployClient: typeof 
+      - uid: '@google-cloud/deploy!v1.CloudDeployClient_2:class'
+        name: v1.CloudDeployClient
+        fullName: v1.CloudDeployClient_2
+      - name: |-
+          ;
+          }
+        fullName: |-
+          ;
+          }
+  - uid: '@google-cloud/deploy!v1.CloudDeployClient_2:class'
+    name: v1.CloudDeployClient
+  - uid: '@google-cloud/deploy!CloudDeployClient~0:complex'
+    name: typeof v1.CloudDeployClient
+    fullName: typeof v1.CloudDeployClient_2
+    spec.typeScript:
+      - name: 'typeof '
+        fullName: 'typeof '
+      - uid: '@google-cloud/deploy!v1.CloudDeployClient_2:class'
+        name: v1.CloudDeployClient
+        fullName: v1.CloudDeployClient_2
+  - uid: '@google-cloud/deploy!v1.CloudDeployClient:class'
+    name: v1.CloudDeployClient
+
+`

--- a/lib/generate-yaml.mjs
+++ b/lib/generate-yaml.mjs
@@ -25,10 +25,15 @@ export default async function generate(opts) {
   const outputDir = join(cwd, 'yaml');
   const tmpDir = opts.tmpDir;
 
+  let mainEntryPointFilePath = join(cwd, 'build', 'src', 'index.d.ts')
+  if (!fs.existsSync(mainEntryPointFilePath)) {
+    mainEntryPointFilePath = join(cwd, 'build', 'cjs', 'src', 'index.d.ts')
+  }
+
   // Create API Extractor config file for the package.
   const apiExtractorConfig = {
     extends: join(cloudRadPath, 'api-extractor.json'),
-    mainEntryPointFilePath: join(cwd, 'build', 'src', 'index.d.ts'),
+    mainEntryPointFilePath: mainEntryPointFilePath,
     projectFolder: cwd,
   };
   const apiExtractorConfigPath = join(cwd, 'api-extractor.json');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/test/specs/lib/generate-devsite.mjs
+++ b/test/specs/lib/generate-devsite.mjs
@@ -23,34 +23,35 @@ import {join} from 'path';
 import snapshots from '../../../__snapshots__/generate-devsite.mjs.js';
 import takeSnapshot from 'snap-shot-it';
 
-let checkSnapshot = () => {};
+const checkSnapshot = (snapshot) => {
+  // The saved snapshot starts and ends with extra newline characters.
+  const value = `\n${snapshot.value}\n`;
 
-before(async () => {
   if (!process.env.SNAPSHOT_UPDATE) {
-    // We want to compare the output with the snapshots, not update snapshots.
-    checkSnapshot = snapshot => {
-      // The saved snapshot starts and ends with extra newline characters.
-      const value = `\n${snapshot.value}\n`;
-
-      assert.deepStrictEqual(value, snapshots[snapshot.key]);
-    };
+    assert.deepStrictEqual(value, snapshots[snapshot.key]);
   }
-
-  // Run the tool.
-  const cwd = mochaHooks.googleCloudDeployDir;
-  const packageInfo = await fs.readJson(
-    join(mochaHooks.googleCloudDeployDir, 'package.json')
-  );
-  const packageShortName = getPackageShortName(packageInfo.name);
-
-  return generateDevsite({
-    cwd,
-    packageInfo,
-    packageShortName,
-  });
-});
+};
 
 describe('cloud-rad docfx generator', () => {
+  before(async () => {
+    // Run the tool.
+    const cwd = mochaHooks.googleCloudDeployDir;
+    const packageInfo = await fs.readJson(
+      join(mochaHooks.googleCloudDeployDir, 'package.json')
+    );
+    const packageShortName = getPackageShortName(packageInfo.name);
+
+    return generateDevsite({
+      cwd,
+      packageInfo,
+      packageShortName,
+    });
+  });
+
+  after(async() => {
+    await fs.rmdir(join(mochaHooks.googleCloudDeployDir, '_devsite'), { recursive: true });
+  });
+
   it('generates a toc.yml file', async () => {
     const tocYml = await fs.readFile(
       join(mochaHooks.googleCloudDeployDir, '_devsite', 'toc.yml'),
@@ -152,6 +153,37 @@ describe('cloud-rad docfx generator', () => {
       'utf8'
     );
     const snapshot = takeSnapshot(contentYml);
+
+    checkSnapshot(snapshot);
+  });
+});
+
+describe('cloud-rad supports CommonJS build for docs entry point', () => {
+  before(async () => {
+    // Rerun the tool for CommonJS build.
+    const cwd = mochaHooks.googleCloudDeployDir;
+    const packageInfo = await fs.readJson(
+      join(mochaHooks.googleCloudDeployDir, 'package.json')
+    );
+    const packageShortName = getPackageShortName(packageInfo.name);
+
+    // Move type files to be within /build/cjs/src.
+    const cjsBuildPathDir = join(cwd, 'build', 'cjs', 'src');
+    await fs.move(join(cwd, 'build', 'src'), cjsBuildPathDir, { recursive: true});
+
+    return generateDevsite({
+      cwd,
+      packageInfo,
+      packageShortName,
+    });
+  });
+
+  it('generates an overview.yml file', async () => {
+    let overviewYml = await fs.readFile(
+      join(mochaHooks.googleCloudDeployDir, '_devsite', 'overview.yml'),
+      'utf8'
+    );
+    const snapshot = takeSnapshot(overviewYml);
 
     checkSnapshot(snapshot);
   });

--- a/test/specs/lib/generate-devsite.mjs
+++ b/test/specs/lib/generate-devsite.mjs
@@ -169,7 +169,7 @@ describe('cloud-rad supports CommonJS build for docs entry point', () => {
 
     // Move type files to be within /build/cjs/src.
     const cjsBuildPathDir = join(cwd, 'build', 'cjs', 'src');
-    await fs.move(join(cwd, 'build', 'src'), cjsBuildPathDir, { recursive: true});
+    await fs.move(join(cwd, 'build', 'src'), cjsBuildPathDir, { recursive: true });
 
     return generateDevsite({
       cwd,


### PR DESCRIPTION
Towards b/361605046.

This supports generating docs when type files that are saved in `<projectFolder>/build/cjs/src/index.d.ts` rather than `<projectFolder>/build/src/index.d.ts`. 