### PR TITLE
chore(auth): use adc instead of service account key for docuploader

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -24,9 +24,6 @@ import {withLogs} from './lib/util.mjs'
 // Deploys the docs.
 function deploy() {
   const bucket = process.env.BUCKET || 'docs-staging-v2';
-  const credentials =
-    process.env.CREDENTIALS ||
-    process.env.KOKORO_KEYSTORE_DIR + '/73713_docuploader_service_account';
 
   return withLogs(execa)('python3', [
     '-m',
@@ -35,8 +32,6 @@ function deploy() {
     './_devsite',
     '--destination-prefix',
     'docfx',
-    '--credentials',
-    credentials,
     '--staging-bucket',
     bucket,
   ], process.cwd());

--- a/main.mjs
+++ b/main.mjs
@@ -24,6 +24,9 @@ import {withLogs} from './lib/util.mjs'
 // Deploys the docs.
 function deploy() {
   const bucket = process.env.BUCKET || 'docs-staging-v2';
+  const credentials =
+    process.env.CREDENTIALS ||
+    process.env.KOKORO_KEYSTORE_DIR + '/73713_docuploader_service_account';
 
   const args = [
     '-m',

--- a/main.mjs
+++ b/main.mjs
@@ -25,7 +25,7 @@ import {withLogs} from './lib/util.mjs'
 function deploy() {
   const bucket = process.env.BUCKET || 'docs-staging-v2';
 
-  return withLogs(execa)('python3', [
+  const args = [
     '-m',
     'docuploader',
     'upload',
@@ -34,7 +34,13 @@ function deploy() {
     'docfx',
     '--staging-bucket',
     bucket,
-  ], process.cwd());
+  ];
+
+  if (credentials) {
+    args.push('--credentials', credentials);
+  }
+
+  return withLogs(execa)('python3', args, process.cwd());
 }
 
 (async () => {


### PR DESCRIPTION
This updates the `docuploader upload` command to use ADC rather than a service account key (provided through a file).