### PR TITLE
fix: handle special packages without @google prefix

### DIFF
--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -19,6 +19,14 @@ import * as url from 'url';
 
 export const cloudRadDir = url.fileURLToPath(new URL('..', import.meta.url));
 
+// Packages without @google prefix.
+const specialPackagesAlreadyInShortnameFormat = new Set([
+  'gaxios',
+  'node-gtoken',
+  'gcp-metadata',
+  'code-suggester',
+]);
+
 export function matchesGlobs(filepath, globPatterns) {
   for (const pattern of globPatterns) {
     if (minimatch(filepath, pattern)) {
@@ -85,6 +93,9 @@ export function withLogs(execaFn) {
  * Retrieves the package short name by removing the namespace prefix for Google libraries.
  */
 export function getPackageShortName(packageName) {
+  if (specialPackagesAlreadyInShortnameFormat.has(packageName)) {
+    return packageName;
+  }
   const packageShortNameRegex = /@google[^\/]+\//g
 
   const hasGoogleNamespace = packageShortNameRegex.test(packageName)

--- a/test/specs/lib/util.mjs
+++ b/test/specs/lib/util.mjs
@@ -36,4 +36,10 @@ describe('get package short name', () => {
     assert.throws(() => getPackageShortName(nonGoogleCloudPackageName), Error)
   });
   
+  it('handle special packages shortnames', async () => {
+    assert.deepEqual(getPackageShortName('gaxios'), 'gaxios');
+    assert.deepEqual(getPackageShortName('node-gtoken'), 'node-gtoken');
+    assert.deepEqual(getPackageShortName('gcp-metadata'), 'gcp-metadata');
+    assert.deepEqual(getPackageShortName('code-suggester'), 'code-suggester');
+  });
 })


### PR DESCRIPTION
Added condition to handle special packages without @google prefix.

Currently docs workflow is failing because of this.
More context: b/423053246