### PR TITLE
fix: check for credentials file before using adc

### DIFF
--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -22,7 +22,7 @@ export const cloudRadDir = url.fileURLToPath(new URL('..', import.meta.url));
 // Packages without @google prefix.
 const specialPackagesAlreadyInShortnameFormat = new Set([
   'gaxios',
-  'node-gtoken',
+  'gtoken',
   'gcp-metadata',
   'code-suggester',
 ]);

--- a/main.mjs
+++ b/main.mjs
@@ -18,6 +18,7 @@
 
 import {execa} from 'execa';
 import createMetadata from './lib/metadata.mjs';
+import fs from 'fs';
 import generateDevsite from './lib/generate-devsite.mjs';
 import {withLogs} from './lib/util.mjs'
 
@@ -39,8 +40,10 @@ function deploy() {
     bucket,
   ];
 
-  if (credentials) {
+  if (credentials && fs.existsSync(credentials)) {
     args.push('--credentials', credentials);
+  } else if (credentials) {
+    console.warn(`Credentials file not found at ${credentials}. Skipping --credentials flag.`);
   }
 
   return withLogs(execa)('python3', args, process.cwd());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/cloud-rad",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "",
   "main": "index.js",
   "repository": "googleapis/cloud-rad",

--- a/test/specs/lib/util.mjs
+++ b/test/specs/lib/util.mjs
@@ -38,7 +38,7 @@ describe('get package short name', () => {
   
   it('handle special packages shortnames', async () => {
     assert.deepEqual(getPackageShortName('gaxios'), 'gaxios');
-    assert.deepEqual(getPackageShortName('node-gtoken'), 'node-gtoken');
+    assert.deepEqual(getPackageShortName('gtoken'), 'gtoken');
     assert.deepEqual(getPackageShortName('gcp-metadata'), 'gcp-metadata');
     assert.deepEqual(getPackageShortName('code-suggester'), 'code-suggester');
   });


### PR DESCRIPTION
Version bumping to `v0.4.10` for this fix as well.

 This fixes a bug where the `KOKORO_KEYSTORE_DIR` variable is set, but the file does not exist, resulting in the `--credentials` flag being used.