### PR TITLE
fix: Ensure deployment checks pass for libraries that have no items to publish

### DIFF
--- a/lib/processors/organize-toc.mjs
+++ b/lib/processors/organize-toc.mjs
@@ -171,7 +171,7 @@ class TocProcessor {
     // reorganize them. We store them in an `items` property so that we can
     // recursively iterate over that property.
     this._items = {
-      items: this._mainItem.items.splice(0),
+      items: this._mainItem.items?.splice(0) || [],
     };
     this._topLevelClasses = [];
 

--- a/lib/processors/organize-toc.mjs
+++ b/lib/processors/organize-toc.mjs
@@ -174,6 +174,7 @@ class TocProcessor {
       // Use an array fallback because `items` might be undefined (e.g. packages like cloud-profiler might not have any sub-items).
       items: this._mainItem.items?.splice(0) || [],
     };
+    this._mainItem.items = [];
     this._topLevelClasses = [];
 
     this.noKind = [];

--- a/lib/processors/organize-toc.mjs
+++ b/lib/processors/organize-toc.mjs
@@ -171,6 +171,7 @@ class TocProcessor {
     // reorganize them. We store them in an `items` property so that we can
     // recursively iterate over that property.
     this._items = {
+      // Use an array fallback because `items` might be undefined (e.g. packages like cloud-profiler might not have any sub-items).
       items: this._mainItem.items?.splice(0) || [],
     };
     this._topLevelClasses = [];

--- a/lib/processors/organize-toc.mjs
+++ b/lib/processors/organize-toc.mjs
@@ -174,6 +174,7 @@ class TocProcessor {
       // Use an array fallback because `items` might be undefined (e.g. packages like cloud-profiler might not have any sub-items).
       items: this._mainItem.items?.splice(0) || [],
     };
+    // The items array will be empty when splicing anyway, but when items is undefined it needs to be set to [] to avoid an error later when concatenating.
     this._mainItem.items = [];
     this._topLevelClasses = [];
 

--- a/test/specs/lib/processors/organize-toc.mjs
+++ b/test/specs/lib/processors/organize-toc.mjs
@@ -763,6 +763,31 @@ describe('organize TOC processor', () => {
     assert.deepStrictEqual(actual, expected);
   });
 
+  it('handles packages with no sub-items gracefully', async () => {
+    const actual = await organizeToc.process({
+      metadata,
+      obj: {
+        items: [
+          {
+            name: 'foo',
+            uid: '@google-cloud/foo!',
+          },
+        ],
+      },
+    });
+    const expected = {
+      items: [
+        {
+          name: 'foo',
+          uid: '@google-cloud/foo!',
+          items: [],
+        },
+      ],
+    };
+
+    assert.deepStrictEqual(actual, expected);
+  });
+
   describe('namespaces', () => {
     let toc;
 


### PR DESCRIPTION
## Description

Deployments are failing like [this](https://fusion2.corp.google.com/invocations/4a150739-4c15-4744-9da1-be427d2d2e3f/targets/cloud-sdk%2Fclient-libraries%2Fnodejs%2Frelease%2Fgoogle-cloud-node%2Fdocs-devsite/log) due to that fact that there are no items to publish. Instead, there shouldn't be a failure, there should just be no failing deployment.

## Impact

This is going to reduce toil on the Node team's rotation because it will reduce the number of failures we need to pay attention too.

## Testing

Added a test that verifies the script works okay when the items value is empty.